### PR TITLE
Simplify code thanks to the curryfication and eta-reduction

### DIFF
--- a/src/commonMain/kotlin/io/smallibs/pilin/control/Applicative.kt
+++ b/src/commonMain/kotlin/io/smallibs/pilin/control/Applicative.kt
@@ -1,5 +1,6 @@
 package io.smallibs.pilin.control
 
+import io.smallibs.pilin.core.Standard.Infix.then
 import io.smallibs.pilin.core.Standard.curry
 import io.smallibs.pilin.type.App
 import io.smallibs.pilin.type.Fun
@@ -14,9 +15,7 @@ object Applicative {
 
     interface WithPureMapAndProduct<F> : Core<F> {
         override suspend fun <A, B> apply(mf: App<F, Fun<A, B>>): Fun<App<F, A>, App<F, B>> =
-            { ma ->
-                map<Pair<Fun<A, B>, A>, B> { p -> p.first(p.second) }(product<Fun<A, B>, A>(mf)(ma))
-            }
+            product<Fun<A, B>, A>(mf) then map { p -> p.first(p.second) }
     }
 
     interface WithPureAndApply<F> : Core<F> {
@@ -34,10 +33,10 @@ object Applicative {
             map(f)
 
         suspend fun <A, B, C> lift2(f: Fun<A, Fun<B, C>>): Fun<App<F, A>, Fun<App<F, B>, App<F, C>>> =
-            curry { ma, mb -> apply(apply(pure(f))(ma))(mb) }
+            apply(pure(f)) then ::apply
 
         suspend fun <A, B, C, D> lift3(f: Fun<A, Fun<B, Fun<C, D>>>): Fun<App<F, A>, Fun<App<F, B>, Fun<App<F, C>, App<F, D>>>> =
-            curry { ma, mb, mc -> apply(lift2(f)(ma)(mb))(mc) }
+            { ma -> lift2(f)(ma) then ::apply }
     }
 
     @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")

--- a/src/commonMain/kotlin/io/smallibs/pilin/control/Applicative.kt
+++ b/src/commonMain/kotlin/io/smallibs/pilin/control/Applicative.kt
@@ -34,11 +34,10 @@ object Applicative {
             map(f)
 
         suspend fun <A, B, C> lift2(f: Fun<A, Fun<B, C>>): Fun<App<F, A>, Fun<App<F, B>, App<F, C>>> =
-            { ma -> { mb -> apply(apply(pure(f))(ma))(mb) } }
+            curry { ma, mb -> apply(apply(pure(f))(ma))(mb) }
 
         suspend fun <A, B, C, D> lift3(f: Fun<A, Fun<B, Fun<C, D>>>): Fun<App<F, A>, Fun<App<F, B>, Fun<App<F, C>, App<F, D>>>> =
-            { ma -> { mb -> { mc -> apply(lift2(f)(ma)(mb))(mc) } } }
-
+            curry { ma, mb, mc -> apply(lift2(f)(ma)(mb))(mc) }
     }
 
     @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")

--- a/src/commonMain/kotlin/io/smallibs/pilin/core/Standard.kt
+++ b/src/commonMain/kotlin/io/smallibs/pilin/core/Standard.kt
@@ -2,6 +2,7 @@ package io.smallibs.pilin.core
 
 import io.smallibs.pilin.type.Fun
 import io.smallibs.pilin.type.Fun2
+import io.smallibs.pilin.type.Fun3
 
 typealias Lambda<A, B> = Fun<A, B>
 typealias Compose<A, B, C> = Lambda<Lambda<B, C>, Lambda<Lambda<A, B>, Lambda<A, C>>>
@@ -18,6 +19,9 @@ object Standard {
 
     suspend fun <A, B, C> curry(f: Fun2<A, B, C>): Fun<A, Fun<B, C>> =
         { a -> { b -> f(a, b) } }
+
+    suspend fun <A, B, C, D> curry(f: Fun3<A, B, C, D>): Fun<A, Fun<B, Fun<C, D>>> =
+        { a -> { b -> { c -> f(a, b, c) } } }
 
     suspend fun <A, B, C> uncurry(f: Fun<A, Fun<B, C>>): Fun2<A, B, C> =
         { a, b -> f(a)(b) }

--- a/src/commonMain/kotlin/io/smallibs/pilin/core/Standard.kt
+++ b/src/commonMain/kotlin/io/smallibs/pilin/core/Standard.kt
@@ -26,6 +26,9 @@ object Standard {
     suspend fun <A, B, C> uncurry(f: Fun<A, Fun<B, C>>): Fun2<A, B, C> =
         { a, b -> f(a)(b) }
 
+    suspend fun <A, B, C, D> uncurry(f: Fun<A, Fun<B, Fun<C, D>>>): Fun3<A, B, C, D> =
+        { a, b, c -> f(a)(b)(c) }
+
     object Infix {
         suspend infix fun <A, B, C> (Fun<B, C>).compose(g: Fun<A, B>): Fun<A, C> =
             { x -> this(g(x)) }

--- a/src/commonMain/kotlin/io/smallibs/pilin/type/Fun.kt
+++ b/src/commonMain/kotlin/io/smallibs/pilin/type/Fun.kt
@@ -3,3 +3,4 @@ package io.smallibs.pilin.type
 typealias Supplier<B> = suspend () -> B
 typealias Fun<A, B> = suspend (A) -> B
 typealias Fun2<A, B, C> = suspend (A, B) -> C
+typealias Fun3<A, B, C, D> = suspend (A, B, C) -> D


### PR DESCRIPTION
Mainly used to simplify lift2 and lift3 code.